### PR TITLE
refactor: patch data in data entity collections repository

### DIFF
--- a/libs/ngxs/repositories/src/ngxs-data-entity-collections/ngxs-data-entity-collections.repository.ts
+++ b/libs/ngxs/repositories/src/ngxs-data-entity-collections/ngxs-data-entity-collections.repository.ts
@@ -179,6 +179,11 @@ export abstract class AbstractNgxsDataEntityCollectionsRepository<
         this.setEntitiesState(this.getState());
     }
 
+    @DataAction()
+    public patchState(@Payload('patchValue') value: Partial<EntityCollections<V, K, C>>): void {
+        this.ctx.patchState(value);
+    }
+
     public setComparator(comparator: EntityComparator<V> | null): this {
         this.comparator = comparator;
 
@@ -350,7 +355,7 @@ export abstract class AbstractNgxsDataEntityCollectionsRepository<
     protected setEntitiesState(state: EntityCollections<V, K, C>): void {
         const ids: K[] = this.sortKeysByComparator(state.ids, state.entities);
 
-        this.ctx.setState({ ...state, ids, entities: state.entities });
+        this.ctx.patchState({ ...state, ids, entities: state.entities });
     }
 
     protected sortKeysByComparator(originalIds: K[], entities: EntityDictionary<K, V>): K[] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
The ngxs data entity collections repository relies heavily on the `setState` method to update its data. It will cause a problem when the user wants to only update part of the record, and not the entire entity collection. Therefore, the goal of this PR is double:

- First is to change the way the data is updated in the state, using `patchState` instead of `setState` in the `setEntityState` method
- Second is to make the `patchState` available to the developer 

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
